### PR TITLE
feat: Add initial dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.gitignore
+Dockerfile
+bin/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.21.1-alpine3.18 as builder
+
+ARG VERSION=v0.0.0
+
+WORKDIR /go/src/mocktimism
+
+RUN apk --update --no-cache add ca-certificates gcc libtool make musl-dev git
+
+COPY Makefile go.mod go.sum ./
+RUN make init && go mod download 
+COPY . .
+RUN make build
+
+FROM alpine:3.18
+
+COPY --from=builder /go/src/mocktimism/bin/mocktimism /usr/local/bin
+ENTRYPOINT ["mocktimism"]
+CMD ["config"]


### PR DESCRIPTION
We want to be able to distribute mocktimism via a docker image. Add dockerfile to be used for this and CI

- Add initial dockerfile to build mocktimism as a docker image

Addresses first 2 items in https://github.com/ethereum-optimism/mocktimism/issues/27
