### PR TITLE
feat: Add l1

### DIFF
--- a/cmd/action_up.go
+++ b/cmd/action_up.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/ethereum-optimism/mocktimism/config"
+	"github.com/ethereum-optimism/mocktimism/service-discovery"
+	"github.com/ethereum-optimism/mocktimism/services/anvil"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	devnetName = "mocktimism-devnet"
+)
+
+func actionUp(ctx *cli.Context) error {
+	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "mocktimism")
+	oplog.SetGlobalLogHandler(log.GetHandler())
+	cfg, err := config.LoadNewConfig(log, ctx.String(ConfigFlag.Name))
+	log.Debug("Loaded config", "cfg", cfg)
+
+	log.Debug("Starting service discovery registry...")
+	servicediscovery.NewServiceDiscovery(devnetName)
+	log.Debug("Starting services...")
+	log.Debug("Starting l1...")
+	anvilService := anvil.NewAnvilService(log.New("role", "l1"))
+	if err := anvilService.Start(ctx.Context); err != nil {
+		log.Error("failed to start l1", "err", err)
+		return err
+	}
+
+	if err != nil {
+		log.Error("failed to load config", "err", err)
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -23,6 +23,12 @@ func newCli(GitCommit string, GitDate string) *cli.App {
 				Description: "Display the current mocktimism config",
 				Action:      actionConfig,
 			},
+			{
+				Name:        "up",
+				Flags:       flags,
+				Description: "Spins up a mocktimism devnet",
+				Action:      actionUp,
+			},
 		},
 	}
 }

--- a/services/l1/op-node.go
+++ b/services/l1/op-node.go
@@ -1,0 +1,48 @@
+package opnode
+
+import (
+	"github.com/ethereum-optimism/mocktimism/service-discovery"
+	"github.com/urfave/cli/v2"
+)
+
+type RollupNodeService struct {
+	ver        string
+	ctx        *cli.Context
+	serviceCfg servicediscovery.ServiceConfig
+}
+
+func (r *RollupNodeService) Hostname() string {
+	return "myRollupNodeHostname"
+}
+
+func (r *RollupNodeService) Port() int {
+	return 8080
+}
+
+func (r *RollupNodeService) ServiceType() string {
+	return "_rollupnode._tcp"
+}
+
+func (r *RollupNodeService) ID() string {
+	return "rollupNode123"
+}
+
+func (r *RollupNodeService) Config() servicediscovery.ServiceConfig {
+	return r.serviceCfg
+}
+
+func (r *RollupNodeService) Start() error {
+	return rollupNodeMainFunc(r.ver, r.ctx)
+}
+
+func NewRollupNodeService(ver string, ctx *cli.Context, config servicediscovery.ServiceConfig) *RollupNodeService {
+	return &RollupNodeService{
+		ver:        ver,
+		ctx:        ctx,
+		serviceCfg: config,
+	}
+}
+
+func rollupNodeMainFunc(ver string, ctx *cli.Context) error {
+	return nil
+}


### PR DESCRIPTION
part of https://github.com/ethereum-optimism/mocktimism/issues/49

Add l1

All services work like this:
- They implement the service interface
- They have their own more specific service specific interface. This allows adapters to be built to plug in different components in future
- They optionally take other service configs as deps

 
