### PR TITLE
feat: Add op-proposer

### DIFF
--- a/services/op-proposer/op-node.go
+++ b/services/op-proposer/op-node.go
@@ -1,0 +1,48 @@
+package opnode
+
+import (
+	"github.com/ethereum-optimism/mocktimism/service-discovery"
+	"github.com/urfave/cli/v2"
+)
+
+type RollupNodeService struct {
+	ver        string
+	ctx        *cli.Context
+	serviceCfg servicediscovery.ServiceConfig
+}
+
+func (r *RollupNodeService) Hostname() string {
+	return "myRollupNodeHostname"
+}
+
+func (r *RollupNodeService) Port() int {
+	return 8080
+}
+
+func (r *RollupNodeService) ServiceType() string {
+	return "_rollupnode._tcp"
+}
+
+func (r *RollupNodeService) ID() string {
+	return "rollupNode123"
+}
+
+func (r *RollupNodeService) Config() servicediscovery.ServiceConfig {
+	return r.serviceCfg
+}
+
+func (r *RollupNodeService) Start() error {
+	return rollupNodeMainFunc(r.ver, r.ctx)
+}
+
+func NewRollupNodeService(ver string, ctx *cli.Context, config servicediscovery.ServiceConfig) *RollupNodeService {
+	return &RollupNodeService{
+		ver:        ver,
+		ctx:        ctx,
+		serviceCfg: config,
+	}
+}
+
+func rollupNodeMainFunc(ver string, ctx *cli.Context) error {
+	return nil
+}


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/mocktimism/issues/49

Add op-proposer

All services work like this:
- They implement the service interface
- They have their own more specific service specific interface. This allows adapters to be built to plug in different components in future
- They optionally take other service configs as deps


