### PR TITLE
:sparkles: feat: search config recursively

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,13 +1,36 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/urfave/cli/v2"
 )
+
+func findConfigFile() string {
+	currentDir, _ := os.Getwd()
+	return findConfigRecursively(currentDir, "mocktimism.toml")
+}
+
+func findConfigRecursively(dir, fileName string) string {
+	configPath := filepath.Join(dir, fileName)
+	if _, err := os.Stat(configPath); err == nil {
+		return configPath
+	}
+
+	parentDir := filepath.Dir(dir)
+	if parentDir == dir {
+		// We've reached the root directory, and the file is not found.
+		return ""
+	}
+
+	return findConfigRecursively(parentDir, fileName)
+}
 
 var (
 	ConfigFlag = &cli.StringFlag{
 		Name:    "config",
-		Value:   "./mocktimism.toml",
+		Value:   findConfigFile(),
 		Aliases: []string{"c"},
 		Usage:   "path to config file",
 		EnvVars: []string{"MOCKTIMISM_CONFIG"},

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Mocktimism can be configured via cli flags or a `mocktimism.toml` file.
+Mocktimism can be configured via cli flags or a `mocktimism.toml` file. By default, `mocktimism.toml` is expected to exist in the root of the package. Otherwise, the program will recursively look for the file.
 
 ## Table of Contents
 - [Global Configuration](#global-configuration)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds a feature whereby the program searches directories recursively for `mocktimism.toml` instead of defaulting to the root or `cmd/`.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #38 
