### PR TITLE
chore: Clean up anvil service

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -26,8 +26,8 @@ silent = false
 
 # l1 chain
 [[profile.default.chains]]
-id = "mainnet"
-base_chain_id = "mainnet"
+name = "mainnet"
+base_chain_id = 1
 
 # Fork options
 fork_chain_id = 1
@@ -48,12 +48,12 @@ allow-origin = "*"
 port = 8545
 host = "127.0.0.1"
 block_time = 12
-prune_history = false
+prune_history = 0
 
 # l2 chain
 [[profile.default.chains]]
-id = "optimism"
-base_chain_id = "mainnet"
+name = "optimism"
+base_chain_id = 1
 
 # Fork options
 fork_chain_id = 10
@@ -74,7 +74,7 @@ allow-origin = "*"
 port = 8546
 host = "127.0.0.1"
 block_time = 2
-prune_history = false
+prune_history = 0
 `
 
 	// TODO can move this to shared test fixture folder https://github.com/ethereum-optimism/mocktimism/issues/29
@@ -85,8 +85,8 @@ prune_history = false
 				Silent: false,
 				Chains: []config.Chain{
 					{
-						ID:                 "mainnet",
-						BaseChainID:        "mainnet",
+						Name:               "mainnet",
+						BaseChainID:        1,
 						ForkChainID:        1,
 						ForkURL:            "https://mainnet.alchemy.infura.io",
 						BlockBaseFeePerGas: 420,
@@ -99,11 +99,11 @@ prune_history = false
 						Port:               8545,
 						Host:               "127.0.0.1",
 						BlockTime:          12,
-						PruneHistory:       false,
+						PruneHistory:       0,
 					},
 					{
-						ID:                 "optimism",
-						BaseChainID:        "mainnet",
+						Name:               "optimism",
+						BaseChainID:        1,
 						ForkChainID:        10,
 						ForkURL:            "https://op.alchemy.infura.io",
 						BlockBaseFeePerGas: 420,
@@ -116,7 +116,7 @@ prune_history = false
 						Port:               8546,
 						Host:               "127.0.0.1",
 						BlockTime:          2,
-						PruneHistory:       false,
+						PruneHistory:       0,
 					},
 				},
 			},
@@ -158,8 +158,8 @@ silent = false
 
 # l1 chain
 [[profile.default.chains]]
-id = "mainnet"
-base_chain_id = "mainnet"
+name = "mainnet"
+base_chain_id = 1
 
 # Fork options
 fork_chain_id = 1
@@ -180,12 +180,12 @@ allow-origin = "*"
 port = 8545
 host = "127.0.0.1"
 block_time = 12
-prune_history = false
+prune_history = 0
 
 # l2 chain
 [[profile.default.chains]]
-id = "optimism"
-base_chain_id = "mainnet"
+name = "optimism"
+base_chain_id = 1
 
 # Fork options
 fork_chain_id = 10
@@ -206,7 +206,7 @@ allow-origin = "*"
 port = 8546
 host = "127.0.0.1"
 block_time = 2
-prune_history = false
+prune_history = 0
 `
 
 	// TODO can move this to shared test fixture folder https://github.com/ethereum-optimism/mocktimism/issues/29
@@ -217,8 +217,8 @@ prune_history = false
 				Silent: false,
 				Chains: []config.Chain{
 					{
-						ID:                 "mainnet",
-						BaseChainID:        "mainnet",
+						Name:               "mainnet",
+						BaseChainID:        1,
 						ForkChainID:        1,
 						ForkURL:            "https://mainnet.alchemy.infura.io",
 						BlockBaseFeePerGas: 420,
@@ -231,11 +231,11 @@ prune_history = false
 						Port:               8545,
 						Host:               "127.0.0.1",
 						BlockTime:          12,
-						PruneHistory:       false,
+						PruneHistory:       0,
 					},
 					{
-						ID:                 "optimism",
-						BaseChainID:        "mainnet",
+						Name:               "optimism",
+						BaseChainID:        1,
 						ForkChainID:        10,
 						ForkURL:            "https://op.alchemy.infura.io",
 						BlockBaseFeePerGas: 420,
@@ -248,7 +248,7 @@ prune_history = false
 						Port:               8546,
 						Host:               "127.0.0.1",
 						BlockTime:          2,
-						PruneHistory:       false,
+						PruneHistory:       0,
 					},
 				},
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -18,21 +18,81 @@ type Profile struct {
 }
 
 type Chain struct {
-	ID                 string `toml:"id"`
-	BaseChainID        string `toml:"base_chain_id"`
-	ForkChainID        int64  `toml:"fork_chain_id"`
-	ForkURL            string `toml:"fork_url"`
-	BlockBaseFeePerGas int64  `toml:"block_base_fee_per_gas"`
-	ChainID            int64  `toml:"chain_id"`
-	GasLimit           int64  `toml:"gas_limit"`
-	Accounts           int    `toml:"accounts"`
-	Balance            int    `toml:"balance"`
-	StepsTracing       bool   `toml:"steps-tracing"`
-	AllowOrigin        string `toml:"allow-origin"`
-	Port               int    `toml:"port"`
-	Host               string `toml:"host"`
-	BlockTime          int    `toml:"block_time"`
-	PruneHistory       bool   `toml:"prune_history"`
+	// The mocktimism name of the chain
+	ID string `toml:"id"`
+	// The base chain ID when the chain is a rollup
+	// If set to 0 or the current chain's ID, the chain is considered an L1 chain
+	BaseChainID int64 `toml:"base_chain_id"`
+	// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
+	// You still must pass both `--fork-url` and `--fork-block-number`, and already have your required state cached on disk, anything missing locally would be fetched
+	// from the remote.
+	ForkChainID int64 `toml:"fork_chain_id"`
+	// Fetch state over a remote endpoint instead of starting from an empty state.
+	// If you want to fetch state from a specific block number, add a block number like `http://localhost:8545@1400000` or use the `fork-block-number` option.
+	ForkURL string `toml:"fork_url"`
+	// The base fee in a block
+	BlockBaseFeePerGas int64 `toml:"block_base_fee_per_gas"`
+	// Set the chain id
+	ChainID int64 `toml:"chain_id"`
+	// Set the gas limit
+	GasLimit int64 `toml:"gas_limit"`
+	// The number of accounts to pre-fund
+	Accounts int `toml:"accounts"`
+	// The initial balance of each account
+	Balance int `toml:"balance"`
+	// Enable steps tracing used for debug calls returning geth-style traces
+	StepsTracing bool `toml:"steps-tracing"`
+	//  Set the CORS allow_origin
+	AllowOrigin string `toml:"allow-origin"`
+	// The port the server will listen on
+	Port int `toml:"port"`
+	// The host the server will listen on
+	Host string `toml:"host"`
+	// Block time in seconds for interval mining.
+	BlockTime int `toml:"block_time"`
+	//  Don't keep full chain history. If a number argument is specified, at most this number of states is kept in memory.
+	PruneHistory int `toml:"prune_history"`
+}
+
+var DefaultProfile = Profile{
+	State:  "",
+	Silent: true,
+	Chains: []Chain{
+		{
+			ID:                 "L1",
+			BaseChainID:        900,
+			ForkChainID:        900,
+			ForkURL:            "",
+			BlockBaseFeePerGas: 1000000000,
+			ChainID:            900,
+			GasLimit:           30_000_000,
+			Accounts:           10,
+			Balance:            1000000000000000000,
+			StepsTracing:       false,
+			AllowOrigin:        "*",
+			Port:               8545,
+			Host:               "localhost",
+			BlockTime:          0,
+			PruneHistory:       0,
+		},
+		{
+			ID:                 "L2",
+			BaseChainID:        901,
+			ForkChainID:        901,
+			ForkURL:            "",
+			BlockBaseFeePerGas: 1000000000,
+			ChainID:            900,
+			GasLimit:           30_000_000,
+			Accounts:           10,
+			Balance:            1000000000000000000,
+			StepsTracing:       false,
+			AllowOrigin:        "*",
+			Port:               9545,
+			Host:               "localhost",
+			BlockTime:          0,
+			PruneHistory:       0,
+		},
+	},
 }
 
 func LoadNewConfig(log log.Logger, path string) (Config, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -18,40 +18,40 @@ type Profile struct {
 }
 
 type Chain struct {
-	// The mocktimism name of the chain
-	ID string `toml:"id"`
+	// The mocktimism name of the chain.
+	Name string `toml:"name"`
+	// Set the chain id
+	ChainID uint `toml:"chain_id"`
 	// The base chain ID when the chain is a rollup
 	// If set to 0 or the current chain's ID, the chain is considered an L1 chain
-	BaseChainID int64 `toml:"base_chain_id"`
+	BaseChainID uint `toml:"base_chain_id"`
 	// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
 	// You still must pass both `--fork-url` and `--fork-block-number`, and already have your required state cached on disk, anything missing locally would be fetched
 	// from the remote.
-	ForkChainID int64 `toml:"fork_chain_id"`
+	ForkChainID uint `toml:"fork_chain_id"`
 	// Fetch state over a remote endpoint instead of starting from an empty state.
 	// If you want to fetch state from a specific block number, add a block number like `http://localhost:8545@1400000` or use the `fork-block-number` option.
 	ForkURL string `toml:"fork_url"`
 	// The base fee in a block
-	BlockBaseFeePerGas int64 `toml:"block_base_fee_per_gas"`
-	// Set the chain id
-	ChainID int64 `toml:"chain_id"`
+	BlockBaseFeePerGas uint `toml:"block_base_fee_per_gas"`
 	// Set the gas limit
-	GasLimit int64 `toml:"gas_limit"`
+	GasLimit uint `toml:"gas_limit"`
 	// The number of accounts to pre-fund
-	Accounts int `toml:"accounts"`
+	Accounts uint `toml:"accounts"`
 	// The initial balance of each account
-	Balance int `toml:"balance"`
+	Balance uint `toml:"balance"`
 	// Enable steps tracing used for debug calls returning geth-style traces
 	StepsTracing bool `toml:"steps-tracing"`
 	//  Set the CORS allow_origin
 	AllowOrigin string `toml:"allow-origin"`
 	// The port the server will listen on
-	Port int `toml:"port"`
+	Port uint `toml:"port"`
 	// The host the server will listen on
 	Host string `toml:"host"`
 	// Block time in seconds for interval mining.
-	BlockTime int `toml:"block_time"`
+	BlockTime uint `toml:"block_time"`
 	//  Don't keep full chain history. If a number argument is specified, at most this number of states is kept in memory.
-	PruneHistory int `toml:"prune_history"`
+	PruneHistory uint `toml:"prune_history"`
 }
 
 var DefaultProfile = Profile{
@@ -59,7 +59,7 @@ var DefaultProfile = Profile{
 	Silent: true,
 	Chains: []Chain{
 		{
-			ID:                 "L1",
+			Name:               "L1",
 			BaseChainID:        900,
 			ForkChainID:        900,
 			ForkURL:            "",
@@ -76,7 +76,7 @@ var DefaultProfile = Profile{
 			PruneHistory:       0,
 		},
 		{
-			ID:                 "L2",
+			Name:               "L2",
 			BaseChainID:        901,
 			ForkChainID:        901,
 			ForkURL:            "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,8 +22,8 @@ silent = false
 
 # l1 chain
 [[profile.default.chains]]
-id = "mainnet"
-base_chain_id = "mainnet"
+name = "mainnet"
+base_chain_id = 1
 
 # Fork options
 fork_chain_id = 1
@@ -44,12 +44,12 @@ allow-origin = "*"
 port = 8545
 host = "127.0.0.1"
 block_time = 12
-prune_history = false
+prune_history = 0
 
 # l2 chain
 [[profile.default.chains]]
-id = "optimism"
-base_chain_id = "mainnet"
+name = "optimism"
+base_chain_id = 1
 
 # Fork options
 fork_chain_id = 10
@@ -70,7 +70,7 @@ allow-origin = "*"
 port = 8546
 host = "127.0.0.1"
 block_time = 2
-prune_history = false
+prune_history = 0
 `
 
 	data := []byte(testData)
@@ -95,47 +95,47 @@ prune_history = false
 		require.Len(t, config.Chains, 2) // Ensure we have 2 chain configurations
 
 		chain1 := config.Chains[0]
-		require.Equal(t, "mainnet", chain1.ID)
-		require.Equal(t, "mainnet", chain1.BaseChainID)
+		require.Equal(t, "mainnet", chain1.Name)
+		require.Equal(t, uint(1), chain1.BaseChainID)
 		// Fork options for the first chain
-		require.Equal(t, int64(1), chain1.ForkChainID)
+		require.Equal(t, uint(1), chain1.ForkChainID)
 		require.Equal(t, "https://mainnet.alchemy.infura.io", chain1.ForkURL)
-		require.Equal(t, int64(420), chain1.BlockBaseFeePerGas)
+		require.Equal(t, uint(420), chain1.BlockBaseFeePerGas)
 		// Chain options for the first chain
-		require.Equal(t, int64(10), chain1.ChainID)
-		require.Equal(t, int64(420), chain1.GasLimit)
+		require.Equal(t, uint(10), chain1.ChainID)
+		require.Equal(t, uint(420), chain1.GasLimit)
 		// EVM options for the first chain
-		require.Equal(t, 10, chain1.Accounts)
-		require.Equal(t, 1000, chain1.Balance)
+		require.Equal(t, uint(10), chain1.Accounts)
+		require.Equal(t, uint(1000), chain1.Balance)
 		require.True(t, chain1.StepsTracing)
 		// Server options for the first chain
 		require.Equal(t, "*", chain1.AllowOrigin)
-		require.Equal(t, 8545, chain1.Port)
+		require.Equal(t, uint(8545), chain1.Port)
 		require.Equal(t, "127.0.0.1", chain1.Host)
-		require.Equal(t, 12, chain1.BlockTime)
-		require.False(t, chain1.PruneHistory)
+		require.Equal(t, uint(12), chain1.BlockTime)
+		require.Equal(t, uint(0), chain1.PruneHistory)
 
 		// Second chain (L2 optimism)
 		chain2 := config.Chains[1]
-		require.Equal(t, "optimism", chain2.ID)
-		require.Equal(t, "mainnet", chain2.BaseChainID)
+		require.Equal(t, "optimism", chain2.Name)
+		require.Equal(t, uint(1), chain2.BaseChainID)
 		// Fork options for the second chain
-		require.Equal(t, int64(10), chain2.ForkChainID)
+		require.Equal(t, uint(10), chain2.ForkChainID)
 		require.Equal(t, "https://op.alchemy.infura.io", chain2.ForkURL)
-		require.Equal(t, int64(420), chain2.BlockBaseFeePerGas)
+		require.Equal(t, uint(420), chain2.BlockBaseFeePerGas)
 		// Chain options for the second chain
-		require.Equal(t, int64(10), chain2.ChainID)
-		require.Equal(t, int64(420), chain2.GasLimit)
+		require.Equal(t, uint(10), chain2.ChainID)
+		require.Equal(t, uint(420), chain2.GasLimit)
 		// EVM options for the second chain
-		require.Equal(t, 10, chain2.Accounts)
-		require.Equal(t, 1000, chain2.Balance)
+		require.Equal(t, uint(10), chain2.Accounts)
+		require.Equal(t, uint(1000), chain2.Balance)
 		require.True(t, chain2.StepsTracing)
 		// Server options for the second chain
 		require.Equal(t, "*", chain2.AllowOrigin)
-		require.Equal(t, 8546, chain2.Port)
+		require.Equal(t, uint(8546), chain2.Port)
 		require.Equal(t, "127.0.0.1", chain2.Host)
-		require.Equal(t, 2, chain2.BlockTime)
-		require.False(t, chain2.PruneHistory)
+		require.Equal(t, uint(2), chain2.BlockTime)
+		require.Equal(t, uint(0), chain2.PruneHistory)
 	}
 
 }


### PR DESCRIPTION
Clean up anvil service. 
- Make it take a chain config instead of arbitrary config
- Validate host and port are set
- Explicitly pass in host and port to anvil everytime
- name service type "anvil" it was previously whatever copilot added
- Get port and host from config

Work towards https://github.com/ethereum-optimism/mocktimism/issues/50
Work towards https://github.com/ethereum-optimism/mocktimism/issues/10
Work towards https://github.com/ethereum-optimism/mocktimism/issues/28