### PR TITLE
feat: Add make all command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 GOPATH:=$(shell go env GOPATH)
 
+.PHONY: all
+all:
+	@make build && make test && make lint && make tidy
+
 .PHONY: update
 update:
 	@go get -u

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -13,9 +13,9 @@ var (
 		EnvVars: []string{"MOCKTIMISM_CONFIG"},
 	}
 	JsonFlag = &cli.BoolFlag{
-		Name: 	 "json",
+		Name:    "json",
 		Aliases: []string{"j"},
-		Usage:	 "print config in JSON form",
+		Usage:   "print config in JSON form",
 		EnvVars: []string{"MOCKTIMISM_CONFIG_JSON"},
 	}
 )

--- a/services/anvil/anvil.go
+++ b/services/anvil/anvil.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/ethereum-optimism/mocktimism/service-discovery"
+	servicediscovery "github.com/ethereum-optimism/mocktimism/service-discovery"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -76,7 +76,7 @@ func (a *AnvilService) Start(ctx context.Context) error {
 
 	err := a.cmd.Start()
 	if err != nil {
-		return fmt.Errorf("failed to start Anvil: %v", err)
+		return fmt.Errorf("failed to start Anvil: %w", err)
 	}
 	return nil
 }
@@ -91,14 +91,14 @@ func (a *AnvilService) Stop() error {
 func (a *AnvilService) HealthCheck() (bool, error) {
 	client, err := rpc.Dial(fmt.Sprintf("http://%s:%d", a.hostname, a.port))
 	if err != nil {
-		return false, fmt.Errorf("failed to dial RPC: %v", err)
+		return false, fmt.Errorf("failed to dial RPC: %w", err)
 	}
 	defer client.Close()
-	
+
 	var result string
 	err = client.Call(&result, "eth_blockNumber")
 	if err != nil {
-		return false, fmt.Errorf("failed to retrieve block number: %v", err)
+		return false, fmt.Errorf("failed to retrieve block number: %w", err)
 	}
 	return result != "", nil
 }


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/mocktimism/issues/40
- Add make all command that runs linter build and tests
- Useful since circle ci hasn't been set up yet
